### PR TITLE
Use `plugins` instead of `plugins_dir` config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ analytics: # Google Analytics
 
 # Build Settings
 markdown: kramdown
-plugins_dir:
+plugins:
   - jekyll-sitemap
   - jekyll-paginate
   - jemoji


### PR DESCRIPTION
As mentioned in jekyll/jekyll#6195, since Jekyll 3.5.0 `plugin_dir` takes a string path to a plugins direcory, defaulting to `./_plugins`, and `plugins` takes a YAML array of plugins for Jekyll to load. Previously, `plugins` was a deprecated alias for `plugins_dir`, taking a string path, and `gems` was the array of plugins to load.