### PR TITLE
Patched to add extra description about the author

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ site-twitter: #if your site has a twitter account, enter it here
 author: David Freeman # add your name
 author-img: david-freeman.jpg # add your photo
 about-author: I am a web developer focusing on front-end development. Always hungry to keep learning. # add description
+about-author-extra-1: Contact me with my email.
+about-author-extra-2: For more detail, check my CV!!
 social-twitter: # add your Twitter handle
 social-facebook: # add your Facebook handle
 social-github: artemsheludko # add your Github handle

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -10,6 +10,8 @@ layout: default
       </div>
       <div class="author-name">{{site.author}}</div>
       <p>{{site.about-author}}</p>
+      <p>{{site.about-author-extra-2}}</p>
+      <p>{{site.about-author-extra-1}}</p>
     </div>
   </header> <!-- End Header -->
   <footer>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -10,8 +10,8 @@ layout: default
       </div>
       <div class="author-name">{{site.author}}</div>
       <p>{{site.about-author}}</p>
-      <p>{{site.about-author-extra-2}}</p>
       <p>{{site.about-author-extra-1}}</p>
+      <p>{{site.about-author-extra-2}}</p>
     </div>
   </header> <!-- End Header -->
   <footer>


### PR DESCRIPTION
While I used your theme for my blog, I noticed that it is hard to write a specific description about me. However, just adding more extra descriptions simply fixed the problem. 

Therefore, I revised your `config.yml` and `main.html` so that the users can make more descriptions easily. 

I applied this revision to my blog, and it looks like this:
<img width="226" alt="Screen Shot 2020-01-05 at 1 46 06 AM" src="https://user-images.githubusercontent.com/38465539/71768813-4e479700-2f5d-11ea-8a8a-a8a21a8962a3.png">

