### PR TITLE
Show pagination only if there is more than one page

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -9,8 +9,10 @@
         {% endif %}
       {% endif %}
 
+      {% if paginator.total_pages > 1 %}
       <p><span class="page-number">Page {{paginator.page}} of {{paginator.total_pages}}</span></p>
-
+      {% endif %}
+      
       {% if paginator.next_page %}
       <p><a class="older-posts" href="{{ site.baseurl }}/page/{{ paginator.next_page }}/"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></a></p>
       {% endif %}


### PR DESCRIPTION
If the blog is still empty the site shows a p tag with content "Page of". If the blog contains only one page the p tag shows "Page 1 of 1". With this PR the pagination-information is only shown if there are at least two pages. 