### PR TITLE
add support for subtitle and post thumbnail image

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,19 @@ layout: main
 ---
 {% for post in paginator.posts %}
 <article class="post">
-  {% if post.img %}
+  {% if post.thumb %}
+    <a class="post-thumbnail" style="background-image: url({{"/assets/img/" | prepend: site.baseurl | append : post.thumb}})" href="{{post.url | prepend: site.baseurl}}"></a>
+  {% elsif post.img %}
     <a class="post-thumbnail" style="background-image: url({{"/assets/img/" | prepend: site.baseurl | append : post.img}})" href="{{post.url | prepend: site.baseurl}}"></a>
   {% else %}
   {% endif %}
   <div class="post-content">
     <h2 class="post-title"><a href="{{post.url | prepend: site.baseurl}}">{{post.title}}</a></h2>
+    {% if post.subtitle %}
+    <p>{{ post.subtitle }}</p>
+    {% else %}
     <p>{{ post.content | strip_html | truncatewords: 15 }}</p>
+    {% endif %}
     <span class="post-date">{{post.date | date: '%Y, %b %d'}}&nbsp;&nbsp;&nbsp;—&nbsp;</span>
     <span class="post-words">{% capture words %}{{ post.content | number_of_words }}{% endcapture %}{% unless words contains "-" %}{{ words | plus: 250 | divided_by: 250 | append: " minute read" }}{% endunless %}</span>
   </div>


### PR DESCRIPTION
@artemsheludko 
I found I wanted a bit more control over the index page listing, specifically:

- Added an option for a different image customized for the index page: `thumb: post-thumbnail.png`
- Added an option for a subtitle, rather than relying on the first 15 words of the post: `subtitle: "Description of the post for the index page"`

Both are optional and default back to the existing behavior, so completely backwards compatible.

Thanks for the great theme!